### PR TITLE
DCE-40: Comment u128 Internal move and Enum Flags hold position data

### DIFF
--- a/src/engine/attacks/pawn.rs
+++ b/src/engine/attacks/pawn.rs
@@ -49,7 +49,7 @@ pub fn get_pawn_mv(color: Color, sq: usize, own: u64, enemy: u64) -> u64 {
     return if moves.is_set(bit) { moves } else { 0 };
 }
 
-pub fn get_pawn_att(color: Color, sq: usize, own: u64, enemy: u64, ep: Option<u64>) -> u64 {
+pub fn get_pawn_att(color: Color, sq: usize, own: u64, enemy: u64, ep: Option<usize>) -> u64 {
     let attacks = PAWN_ATTACK[color.idx()][sq] & !own;
     match ep {
         Some(ep) => return attacks & (enemy | get_pawn_ep(color, ep)),
@@ -57,10 +57,10 @@ pub fn get_pawn_att(color: Color, sq: usize, own: u64, enemy: u64, ep: Option<u6
     }
 }
 
-pub fn get_pawn_ep(color: Color, ep: u64) -> u64 {
-    let rank_ep = get_bit_rank(ep.get_lsb());
+pub fn get_pawn_ep(color: Color, ep: usize) -> u64 {
+    let rank_ep = get_bit_rank(ep);
     if (rank_ep == Rank::Six && color.is_white()) || (rank_ep == Rank::Three && color.is_black()) {
-        return ep;
+        return 1 << ep;
     } else {
         return 0;
     }

--- a/src/engine/game.rs
+++ b/src/engine/game.rs
@@ -14,7 +14,7 @@ pub struct Game {
     pub bitboard: [Bitboard; 14],
     pub color: Color,
     pub castling: CastlingRights,
-    pub ep: Option<Bitboard>,
+    pub ep: Option<usize>,
     pub half_move: usize,
     pub full_move: usize,
     pub pos_key: u64,

--- a/src/engine/move_generation/fen.rs
+++ b/src/engine/move_generation/fen.rs
@@ -1,5 +1,6 @@
 use crate::engine::game::Game;
 use crate::engine::shared::helper_func::bit_pos_utility::*;
+use crate::engine::shared::helper_func::bitboard::BitboardTrait;
 use crate::engine::shared::structures::castling_struct::*;
 use crate::engine::shared::structures::color::*;
 use crate::engine::shared::structures::piece::*;
@@ -64,7 +65,7 @@ impl FenTrait for Game {
         self.ep = match square {
             "-" => None,
             s => match position_to_bit(s) {
-                Ok(bit) => Some(bit),
+                Ok(bit) => Some(bit.get_lsb()),
                 Err(e) => panic!("Unknown En Passant Position: {}", e),
             },
         }
@@ -135,7 +136,7 @@ mod tests {
         let game = Game::read_fen(FEN_PAWNS_BLACK);
         assert_eq!(game.color, BLACK);
         assert_eq!(game.castling, CastlingRights::ALL);
-        assert_eq!(game.ep, Some(1 << SqPos::E3 as usize));
+        assert_eq!(game.ep, Some(SqPos::E3 as usize));
         assert_eq!(game.half_move, 0);
         assert_eq!(game.full_move, 1);
 

--- a/src/engine/move_generation/perft.rs
+++ b/src/engine/move_generation/perft.rs
@@ -99,11 +99,11 @@ pub fn perft(depth: usize, game: &mut Game, stats: &mut Stats) -> u64 {
 
         if depth == 1 {
             match move_list[i].flag {
-                Flag::Normal => stats.add_node(),
-                Flag::Capture => stats.add_capture(),
-                Flag::EP => stats.add_ep(),
-                Flag::Promotion => stats.add_promotion(),
-                Flag::KingSideCastle | Flag::QueenSideCastle => stats.add_castle(),
+                Flag::Quiet => stats.add_node(),
+                Flag::Capture(_) => stats.add_capture(),
+                Flag::EP(_, _) => stats.add_ep(),
+                Flag::Promotion(_, _) => stats.add_promotion(),
+                Flag::KingSideCastle(_, _) | Flag::QueenSideCastle(_, _) => stats.add_castle(),
             }
         }
 
@@ -127,7 +127,7 @@ pub fn init_test_func(fen: &str, depth: usize, dispaly_stats: bool) -> Stats {
 }
 
 pub fn profiler_init_test_func(fen: &str, depth: usize, dispaly_stats: bool) -> Stats {
-    let guard = pprof::ProfilerGuardBuilder::default().frequency(1000).build().unwrap();
+    let guard = pprof::ProfilerGuardBuilder::default().frequency(10000).build().unwrap();
 
     let stats = init_test_func(fen, depth, dispaly_stats);
 

--- a/src/engine/shared/helper_func/print_utility.rs
+++ b/src/engine/shared/helper_func/print_utility.rs
@@ -89,7 +89,12 @@ pub fn move_notation(sq_from: usize, sq_to: usize, promotion: Option<Piece>) -> 
 
 pub fn print_move_list(moves: &Vec<InternalMove>) {
     for (idx, mv) in moves.iter().enumerate() {
-        println!("{}. Move: {}, (Score: {})", idx, move_notation(mv.from, mv.to, mv.promotion), 0);
+        let promotion = match mv.flag {
+            Flag::Promotion(_, cap_piece) => cap_piece,
+            _ => None,
+        };
+
+        println!("{}. Move: {}, (Score: {})", idx, move_notation(mv.from, mv.to, promotion), 0);
     }
 }
 

--- a/src/engine/shared/structures/castling_struct.rs
+++ b/src/engine/shared/structures/castling_struct.rs
@@ -5,7 +5,13 @@ use crate::engine::move_generation::move_generation::*;
 use crate::engine::shared::structures::square::SqPos::*;
 use super::color::*;
 
-// TODO: Needs a little reaserch because it does not sum all of this.
+pub const CASTLE_DATA: [(usize, usize, CastlingRights, Color); 4] = [
+    (H1 as usize, E1 as usize, CastlingRights::WKINGSIDE, WHITE),
+    (A1 as usize, E1 as usize, CastlingRights::WQUEENSIDE, WHITE),
+    (H8 as usize, E8 as usize, CastlingRights::BKINGSIDE, BLACK),
+    (A8 as usize, E8 as usize, CastlingRights::BQUEENSIDE, BLACK),
+];
+
 bitflags! {
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct CastlingRights: u8 {

--- a/src/engine/shared/structures/internal_move.rs
+++ b/src/engine/shared/structures/internal_move.rs
@@ -1,7 +1,6 @@
 use std::ops::Add;
 
 use super::castling_struct::*;
-use super::piece;
 use super::piece::*;
 use super::color::*;
 
@@ -9,12 +8,12 @@ use super::color::*;
 // DEPRECATE:
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Flag {
-    Normal = 1,
-    Capture = 2,
-    EP = 4,
-    Promotion = 8,
-    KingSideCastle = 16,
-    QueenSideCastle = 32,
+    Quiet,
+    Capture(Piece),
+    EP(usize, Piece),
+    Promotion(Piece, Option<Piece>),
+    KingSideCastle(usize, usize),
+    QueenSideCastle(usize, usize),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -24,9 +23,7 @@ pub struct InternalMove {
     pub from: usize,
     pub to: usize,
     pub piece: Piece,
-    pub captured: Option<Piece>,
-    pub promotion: Option<Piece>,
-    pub ep: Option<u64>,
+    pub ep: Option<usize>,
     pub castle: CastlingRights,
     pub flag: Flag,
     pub half_move: usize,
@@ -41,260 +38,10 @@ impl InternalMove {
             from: 0,
             to: 0,
             piece: 0,
-            captured: None,
-            promotion: None,
             ep: None,
             castle: CastlingRights::NONE,
-            flag: Flag::Normal,
+            flag: Flag::Quiet,
             half_move: 0,
         };
     }
 }
-
-// pub type Position = u128;
-
-// trait PositionGetTrait {
-//     fn parse(&self, shift: usize, bits: usize) -> u64;
-//     fn get_from(&self) -> u8;
-//     fn get_to(&self) -> u8;
-//     fn get_piece(&self) -> u8;
-//     fn get_color(&self) -> u8;
-//     fn get_captured(&self) -> Option<Piece>;
-//     fn get_promotion(&self) -> Option<Piece>;
-//     fn get_ep(&self) -> Option<usize>;
-//     fn get_castle(&self) -> CastlingRights;
-//     fn get_flag(&self) -> Flag;
-//     fn get_half_move(&self) -> usize;
-//     fn get_key(&self) -> u64;
-//     #[rustfmt::skip]
-//     fn get_all(&self) -> (u8, u8, u8, u8, Option<Piece>, Option<Piece>, Option<usize>, CastlingRights, Flag, usize, u64);
-// }
-
-// impl PositionGetTrait for Position {
-//     fn parse(&self, shift: usize, bits: usize) -> u64 {
-//         return ((self >> shift) & (((1 << bits) as u128) - 1)) as u64;
-//     }
-
-//     fn get_from(&self) -> u8 {
-//         return self.parse(0, 7) as u8;
-//     }
-
-//     fn get_to(&self) -> u8 {
-//         return self.parse(7, 7) as u8;
-//     }
-
-//     fn get_piece(&self) -> u8 {
-//         return self.parse(14, 7) as u8;
-//     }
-
-//     fn get_color(&self) -> u8 {
-//         return self.get_piece().color();
-//     }
-
-//     fn get_captured(&self) -> Option<Piece> {
-//         match self.parse(21, 7) as u8 {
-//             0 => return None,
-//             piece => return Some(piece),
-//         }
-//     }
-
-//     fn get_promotion(&self) -> Option<Piece> {
-//         match self.parse(28, 7) as u8 {
-//             0 => return None,
-//             piece => return Some(piece),
-//         }
-//     }
-
-//     fn get_ep(&self) -> Option<usize> {
-//         match self.parse(35, 7) as u8 {
-//             0 => return None,
-//             sq => return Some(sq as usize),
-//         }
-//     }
-
-//     fn get_castle(&self) -> CastlingRights {
-//         let castle = self.parse(42, 4) as u8;
-//         let mut rez: CastlingRights = CastlingRights::NONE;
-//         if castle & 1 != 0 {
-//             rez.add(CastlingRights::WKINGSIDE);
-//         }
-//         if castle & 2 != 0 {
-//             rez.add(CastlingRights::WQUEENSIDE);
-//         }
-//         if castle & 4 != 0 {
-//             rez.add(CastlingRights::BKINGSIDE);
-//         }
-//         if castle & 8 != 0 {
-//             rez.add(CastlingRights::BQUEENSIDE);
-//         }
-//         return rez;
-//     }
-
-//     fn get_flag(&self) -> Flag {
-//         match self.parse(46, 6) as u8 {
-//             1 => return Flag::Normal,
-//             2 => return Flag::Capture,
-//             4 => return Flag::EP,
-//             8 => return Flag::Promotion,
-//             16 => return Flag::KingSideCastle,
-//             32 => return Flag::QueenSideCastle,
-//             _ => panic!(""),
-//         }
-//     }
-
-//     fn get_half_move(&self) -> usize {
-//         return self.parse(52, 6) as usize;
-//     }
-
-//     fn get_key(&self) -> u64 {
-//         return self.parse(58, 64);
-//     }
-
-//     fn get_all(
-//         &self,
-//     ) -> (
-//         u8,
-//         u8,
-//         u8,
-//         u8,
-//         Option<Piece>,
-//         Option<Piece>,
-//         Option<usize>,
-//         CastlingRights,
-//         Flag,
-//         usize,
-//         u64,
-//     ) {
-//         return (
-//             self.get_from(),
-//             self.get_to(),
-//             self.get_piece(),
-//             self.get_color(),
-//             self.get_captured(),
-//             self.get_promotion(),
-//             self.get_ep(),
-//             self.get_castle(),
-//             self.get_flag(),
-//             self.get_half_move(),
-//             self.get_key(),
-//         );
-//     }
-// }
-
-// trait PositionSetTrait {
-//     fn set(&mut self, shift: usize, bits: u128);
-//     fn set_from(&mut self, from: u8);
-//     fn set_to(&mut self, to: u8);
-//     fn set_piece(&mut self, piece: u8);
-//     fn set_color(&mut self, color: u8);
-//     fn set_captured(&mut self, captured: Option<Piece>);
-//     fn set_promotion(&mut self, promotion: Option<Piece>);
-//     fn set_ep(&mut self, ep: Option<usize>);
-//     fn set_castle(&mut self, castle: CastlingRights);
-//     fn set_flag(&mut self, flag: Flag);
-//     fn set_half_move(&mut self, half_move: usize);
-//     fn set_key(&mut self, key: u64);
-// }
-
-// impl PositionSetTrait for Position {
-//     fn set(&mut self, shift: usize, bits: u128) {
-//         *self |= bits << shift;
-//     }
-
-//     fn set_from(&mut self, from: u8) {
-//         self.set(0, from as u128);
-//     }
-
-//     fn set_to(&mut self, to: u8) {
-//         self.set(7, to as u128);
-//     }
-
-//     fn set_piece(&mut self, piece: u8) {
-//         self.set(14, piece as u128);
-//     }
-
-//     fn set_color(&mut self, color: u8) {
-//         self.set(14, color as u128);
-//     }
-
-//     fn set_captured(&mut self, captured: Option<Piece>) {
-//         match captured {
-//             Some(piece) => self.set(21, piece as u128),
-//             None => (),
-//         }
-//     }
-
-//     fn set_promotion(&mut self, promotion: Option<Piece>) {
-//         match promotion {
-//             Some(piece) => self.set(28, piece as u128),
-//             None => (),
-//         }
-//     }
-
-//     fn set_ep(&mut self, ep: Option<usize>) {
-//         match ep {
-//             Some(piece) => self.set(35, piece as u128),
-//             None => (),
-//         }
-//     }
-
-//     fn set_castle(&mut self, castle: CastlingRights) {
-//         if castle.is_set(CastlingRights::WKINGSIDE) {
-//             self.set(14, 1 as u128)
-//         }
-//         if castle.is_set(CastlingRights::WQUEENSIDE) {
-//             self.set(14, 1 as u128)
-//         }
-//         if castle.is_set(CastlingRights::BKINGSIDE) {
-//             self.set(14, 1 as u128)
-//         }
-//         if castle.is_set(CastlingRights::BQUEENSIDE) {
-//             self.set(14, 1 as u128)
-//         }
-//     }
-
-//     fn set_flag(&mut self, flag: Flag) {
-//         match flag {
-//             Flag::Normal => self.set(14, 1 as u128),
-//             Flag::Capture => self.set(14, 1 as u128),
-//             Flag::EP => self.set(14, 1 as u128),
-//             Flag::Promotion => self.set(14, 1 as u128),
-//             Flag::KingSideCastle => self.set(14, 1 as u128),
-//             Flag::QueenSideCastle => self.set(14, 1 as u128),
-//         }
-//     }
-
-//     fn set_half_move(&mut self, half_move: usize) {
-//         self.set(14, 1 as u128)
-//     }
-
-//     fn set_key(&mut self, key: u64) {
-//         self.set(14, key as u128)
-//     }
-// }
-
-// NOTE: If Performance is better without enum and struct
-// Change InternalMove from struct to u128 where you will store all relevant information as one integer
-// 64 bits -> position key (IF NECESSARY)
-// 8 bits -> color and piece
-// 7 bits -> from position
-// 7 bits -> to position
-// 8 bits -> color and piece captured
-// 4 bits -> promotion piece (knight, bishop, rook, queen)
-// 4 bits -> Castling Rights (wKingSIde, wQueenSide, bKingSIde, bQueenSide)
-// 7 bits -> ep position
-// other bits -> maybe for score
-
-// TODO: Generate position key every time a move is created
-
-// 0 from (7 bits) ->
-// 7 to (7 bits) ->
-// 14 piece | color (7 bits) ->
-// 21 captured (7 bits) ->
-// 28 promotion (7 bits) ->
-// 35 ep( 7 bits) ->
-// 42 castle (4 bits) ->
-// 46 flag (6 bits) ->
-// 52 half_move (7 bits) ->
-// 59 key (64 bits) ->
-// 123 final


### PR DESCRIPTION
# Jira Ticket: DCE-40
## Summary (Provide a summary of the changes.)
- Now Flag Enums Hold Position Data
- Removed u128 Internal Move
- Castling Data is now a const inside Castling Struct. (Improved by 0.5 sec when used as ref).
- get_occupancy, add_ep_move and add_promotion_move are updated.
- Added Quiet Move Function Inside Make Move.
- 

## Checklist
- [x] All Tests are Correct.
- [x] Merged with the master branch.

## Additional Notes (Any additional context, screenshots, or relevant information.)

